### PR TITLE
[noticket] Use environment for PHP version to allow customization in downstream configurations.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,5 +3,6 @@ export NIXPKGS_ALLOW_UNFREE=1
 watch_file devenv.nix
 watch_file devenv.yaml
 watch_file devenv.lock
+watch_file devenv.local.nix
 
 eval "$(devenv print-dev-env)"

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1674493087,
-        "narHash": "sha256-NaOxJFcSKmuFIGwluXkLmk2RiOw8IKk2LY6RrsQd0NA=",
+        "lastModified": 1674674506,
+        "narHash": "sha256-yTkjkuPEX56bMK8QEv/Ol62cem2A80LzwUsYvMKQmoE=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c5519d64b6bbf59be0d37a26a801a2e9430bcb3f",
+        "rev": "c6e7721ab49e51ca75ebbc07064c6a2285a4afc1",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674211260,
-        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
+        "lastModified": 1674641431,
+        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
+        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1674376774,
-        "narHash": "sha256-FNpgwgN7Z2ul/95ykUal8sPc2aJW9rfc5MZ0TAC0Plo=",
+        "lastModified": 1674685049,
+        "narHash": "sha256-wGQvegtPFNV4OIWth64/dyuIDo52w8aedxfxAbUm7uI=",
         "owner": "fossar",
         "repo": "nix-phps",
-        "rev": "a74d5a1e3a1ab3bfc469fd22f668d15a4919c91e",
+        "rev": "7e53d72f6a0f994ed99ff9d30b616bd9bc23af73",
         "type": "github"
       },
       "original": {
@@ -150,11 +150,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1674487663,
-        "narHash": "sha256-wuDr8rfBLcY7EIsFrFEj2dKYvsKjGib42Q2X3ZaDVf4=",
+        "lastModified": 1674761200,
+        "narHash": "sha256-v0ypL0eDhFWmgd3f5nnbffaMA5BUoOnYUiEso7fk+q0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3a12b647bc6da39b69bffcc7aaa31cdbc9b7ff7c",
+        "rev": "8539119ba0b17b15e60de60da0348d8c73bbfdf2",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -44,11 +44,6 @@ let
     extraConfig = phpConfig;
   };
 
-  requiredFiles = [
-    ".env"
-    "install.lock"
-  ];
-
   entryScript = pkgs.writeScript "entryScript" ''
     PATH="${lib.makeBinPath [ pkgs.coreutils ]}:$PATH"
 
@@ -58,14 +53,7 @@ let
 
     ${updateConfig} core.mailerSettings.emailAgent ""
 
-    for FILE in ${lib.escapeShellArgs requiredFiles}; do
-    echo -e $FILE
-      if ! test -f "$FILE"; then
-        touch $FILE
-      fi
-    done
-
-    echo -e "\nStartup completed"
+    echo -e "Startup completed"
 
     sleep infinity
   '';

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,7 +1,7 @@
 { pkgs, config, inputs, lib, ... }:
 
 let
-  phpVersion = "php81";
+  phpVersion = config.env.PHP_VERSION;
 
   phpConfig = ''
     date.timezone = Europe/Berlin
@@ -37,7 +37,7 @@ let
   '';
 
   phpPackage = inputs.phps.packages.${builtins.currentSystem}.${phpVersion}.buildEnv {
-    extensions = { all, enabled }: with all; enabled ++ [ redis blackfire ];
+    extensions = { all, enabled }: with all; enabled ++ [ redis ];
     extraConfig = phpConfig;
   };
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -150,6 +150,8 @@ let
     echo Uuid::randomHex();
   '';
 in {
+  env.PHP_VERSION = lib.mkDefault "php81";
+
   packages = [
     pkgs.jq
     pkgs.gnupatch

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,6 +1,8 @@
 { pkgs, config, inputs, lib, ... }:
 
 let
+  phpVersion = config.env.PHP_VERSION;
+
   phpConfig = ''
     date.timezone = Europe/Berlin
     memory_limit = 2G
@@ -34,12 +36,12 @@ let
     xdebug.var_display_max_children = -1
   '';
 
-  phpPackage = inputs.phps.packages.${builtins.currentSystem}.${config.env.PHP_VERSION}.buildEnv {
-    extensions = { all, enabled }: with all; enabled ++ [ redis blackfire ];
+  phpPackage = inputs.phps.packages.${builtins.currentSystem}.${phpVersion}.buildEnv {
+    extensions = { all, enabled }: with all; enabled ++ [ redis ] ++ (lib.optional config.services.blackfire.enable blackfire);
     extraConfig = phpConfig;
   };
 
-  phpXdebug = inputs.phps.packages.${builtins.currentSystem}.${config.env.PHP_VERSION}.buildEnv {
+  phpXdebug = inputs.phps.packages.${builtins.currentSystem}.${phpVersion}.buildEnv {
     extensions = { all, enabled }: with all; enabled ++ [ redis xdebug ];
     extraConfig = phpConfig;
   };

--- a/example/devenv.nix
+++ b/example/devenv.nix
@@ -1,7 +1,8 @@
 { pkgs, config, inputs, lib, ... }:
 
 let
-  phpVersion = "php81";
+  phpVersion = config.env.PHP_VERSION;
 in
 {
+  env.PHP_VERSION = "php74";
 }

--- a/example/devenv.nix
+++ b/example/devenv.nix
@@ -1,3 +1,3 @@
 {
-  env.PHP_VERSION = "php74";
+  env.PHP_VERSION = "php81";
 }

--- a/example/devenv.nix
+++ b/example/devenv.nix
@@ -1,3 +1,3 @@
 {
-  env.PHP_VERSION = "php81";
+  env.PHP_VERSION = "php74";
 }

--- a/example/devenv.nix
+++ b/example/devenv.nix
@@ -1,8 +1,3 @@
-{ pkgs, config, inputs, lib, ... }:
-
-let
-  phpVersion = config.env.PHP_VERSION;
-in
 {
   env.PHP_VERSION = "php74";
 }


### PR DESCRIPTION
Blackfire is incompatible with PHP < 8, so let's remove it for now from the standard configuration 🙂
Also, use the environment to fix PHP version customization, which was not working correctly before.