### PR TITLE
Downgrade nodejs version from 18 to 16

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -158,7 +158,7 @@ in {
   ];
 
   languages.javascript.enable = true;
-  languages.javascript.package = lib.mkDefault pkgs.nodejs-18_x;
+  languages.javascript.package = lib.mkDefault pkgs.nodejs-16_x;
   env.NODE_OPTIONS = "--openssl-legacy-provider --max-old-space-size=2000";
 
   languages.php.enable = true;


### PR DESCRIPTION
Executing the `bin/build-js.sh` script shows a Deprecated-warning:
`@Deprecated: You are using an incompatible Node.js version. Supported version range: ^16.0.0`