### PR TITLE
Remove redeclaration of default setting

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -253,7 +253,6 @@ in {
   services.adminer.listen = lib.mkDefault "127.0.0.1:8010";
 
   services.mailhog.enable = true;
-  services.mailhog.uiListenAddress = lib.mkDefault "127.0.0.1:8025";
 
   # services.elasticsearch.enable = true;
   # services.rabbitmq.enable = true;


### PR DESCRIPTION
Setting `services.mailhog.uiListenAddress` is already set to `"127.0.0.1:8025"` by default:   https://devenv.sh/reference/options/#servicesmailhoguilistenaddress