### PR TITLE
Make importdb more visible in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ kellerkinder.enableElasticsearch = true;
 
 ### kellerkinder.importDatabaseDumps
 
-Define the list of links to be imported with command importdb.
+You can import a list of links of database dumps by using the command `importdb`.
+Define a list of links like in the example below.
+
 Supported files:
 - *.sql
 - *.gz


### PR DESCRIPTION
Turned out, I haven't seen, that there is a command to import the list of links.

This PR will highlight the existence of the command a little bit.