### PR TITLE
adjust example config to enable additional services

### DIFF
--- a/examples/sw6/devenv.nix
+++ b/examples/sw6/devenv.nix
@@ -6,6 +6,6 @@
     memory_limit = 512M
   '';
   kellerkinder.additionalPhpExtensions = [ "mailparse" ];
-  kellerkinder.enableRabbitMq = false;
-  kellerkinder.enableElasticsearch = false;
+  kellerkinder.enableRabbitMq = true;
+  kellerkinder.enableElasticsearch = true;
 }


### PR DESCRIPTION
We should not show example of default values.