### PR TITLE
fix: Add changes of publish_docs_to_wiki.yml as trigger for pipeline

### DIFF
--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - docs/**
+      - .github/workflows/publish_docs_to_wiki.yml
     branches:
       - main
 


### PR DESCRIPTION
<!--
Thank you for contributing to our devenv project!

It would be helpful if you could provide us with as much information as possible so we can better process your pull request.
Therefore you are given this description template.
-->

### 1. Why is this change necessary?
Changes to the pipeline for publishing docs to wiki are not triggering it.

### 2. What does this change do, exactly?
Add file to paths that are checked.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written or adjusted the documentation according to my changes
