### PR TITLE
[noticket] Add skip if mysqladmin is missing

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -58,6 +58,11 @@ let
   entryScript = pkgs.writeScript "entryScript" ''
     set -euo pipefail
 
+    if [ ! -f $DEVENV_PROFILE/bin/mysqladmin ]; then
+      echo -e "mysqladmin missing, skips further entryscript processing"
+      ${pkgs.coreutils}/bin/sleep infinity
+    fi
+
     while ! $DEVENV_PROFILE/bin/mysqladmin ping --silent; do
       ${pkgs.coreutils}/bin/sleep 1
     done


### PR DESCRIPTION
<!--
Thank you for contributing to our devenv project!

It would be helpful if you could provide us with as much information as possible so we can better process your pull request.
Therefore you are given this description template.
-->

### 1. Why is this change necessary?
See #32 

### 2. What does this change do, exactly?
Skips further execution of the entry script if `mysqladmin` is missing

### 3. Describe each step to reproduce the issue or behaviour.
See #32 

### 4. Please link to the relevant issues (if any).
#32 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
