### PR TITLE
Add REDIS_DSN to env vars if enabled

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -422,6 +422,9 @@ in {
       (lib.mkIf config.services.rabbitmq.enable {
         RABBITMQ_NODENAME = "rabbit@localhost"; # 127.0.0.1 can't be used as rabbitmq can't set short node name
       })
+      (lib.mkIf config.services.redis.enable {
+        REDIS_DSN = "redis://127.0.0.1:6379";
+      })
     ];
 
     # Processes


### PR DESCRIPTION
### 1. Why is this change necessary?

REDIS_DSN is not set if Redis is enabled.

### 2. What does this change do, exactly?

It adds REDIS_DSN to the env vars, if Redis is enabled.

### 3. Describe each step to reproduce the issue or behaviour.

Any devenv setup importing this with redis enabled, does not have REDIS_DSN set.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
