### PR TITLE
[noticket] Add fix for devenv usage outside of project folder

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -87,14 +87,14 @@ let
   systemConfigEntries = lib.mapAttrsToList (name: value: { inherit name value; }) cfg.systemConfig;
 
   scriptUpdateConfig = pkgs.writeScript "scriptUpdateConfig" ''
-    VENDOR=${config.env.DEVENV_ROOT}/vendor/autoload.php
-    CONSOLE=${config.env.DEVENV_ROOT}/bin/console
+    VENDOR=${config.env.DEVENV_ROOT}/${cfg.projectRoot}/vendor/autoload.php
+    CONSOLE=${config.env.DEVENV_ROOT}/${cfg.projectRoot}/bin/console
 
     echo "Updating system config"
 
     if [ ! -f "$VENDOR" ] || [ ! -f "$CONSOLE" ]; then
       echo "Vendor folder or console not found. Please run composer install."
-      ${pkgs.coreutils}/bin/sleep infinity
+      exit 1
     fi
 
     # additional config
@@ -231,6 +231,13 @@ in {
       type = lib.types.str;
       default = "public";
       description = "Sets the docroot of caddy";
+    };
+
+    projectRoot = lib.mkOption {
+      type = lib.types.str;
+      default = ".";
+      description = "Root of the project as path from the file devenv.nix";
+      example = "project";
     };
 
     staticFilePaths = lib.mkOption {
@@ -444,7 +451,7 @@ in {
 
     # Symfony related scripts
     scripts.cc.exec = ''
-      CONSOLE=${config.env.DEVENV_ROOT}/bin/console
+      CONSOLE=${config.env.DEVENV_ROOT}${cfg.projectRoot}/bin/console
 
       if test -f "$CONSOLE"; then
         exec $CONSOLE cache:clear

--- a/devenv.nix
+++ b/devenv.nix
@@ -94,7 +94,7 @@ let
 
     if [ ! -f "$VENDOR" ] || [ ! -f "$CONSOLE" ]; then
       echo "Vendor folder or console not found. Please run composer install."
-      exit 1
+      ${pkgs.coreutils}/bin/sleep infinity
     fi
 
     # additional config

--- a/devenv.nix
+++ b/devenv.nix
@@ -323,7 +323,7 @@ in {
 
             tls internal
 
-            root * ${cfg.documentRoot}
+            root * ${cfg.projectRoot}/${cfg.documentRoot}
 
             encode zstd gzip
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -100,11 +100,11 @@ kellerkinder.documentRoot = ".";
 ```
 
 # kellerkinder.projectRoot
-Changes the default root of the project to the specified value
+Changes the default root of the project to the specified value (no `/` as pre- or suffix required)
 
-*_Example for the current folder_*
+*_Example for a `project` folder inside the current folder_*
 ```
-kellerkinder.documentRoot = "/project";
+kellerkinder.projectRoot = "project";
 ```
 
 # kellerkinder.staticFilePaths

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -99,6 +99,14 @@ Changes the default document root (`public`) of caddy to the specified value
 kellerkinder.documentRoot = ".";
 ```
 
+# kellerkinder.projectRoot
+Changes the default root of the project to the specified value
+
+*_Example for the current folder_*
+```
+kellerkinder.documentRoot = "/project";
+```
+
 # kellerkinder.staticFilePaths
 Adjusts the defined matcher paths for caddy. You might want to adjust those to access/handle `*.php` files.
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If devenv is placed in the parent folder of the project - whyever - this will result in an exit instead of keeping the project running
### 2. What does this change do, exactly?
Switch an `exit` with a `sleep`

### 3. Describe each step to reproduce the issue or behaviour.
Setup a new project, run and setup it initially and restart devenv

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
