### PR TITLE
[NOTICKET] set mysql 8.0 as default database

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -356,6 +356,7 @@ in {
 
     services.mysql = {
       enable = lib.mkDefault true;
+      package = lib.mkDefault pkgs.mysql80;
       initialDatabases = lib.mkDefault [{ name = "shopware"; }];
       ensureUsers = lib.mkDefault [{
         name = "shopware";


### PR DESCRIPTION
### 1. Why is this change necessary?
https://github.com/cachix/devenv/commit/4e5a2d53335c5858200715a7c56e648ee6ceb551

devenv changed the default, which broke my database for one project unattended.

### 2. What does this change do, exactly?
Set mysql80 as default

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
