### PR TITLE
fix: [NOTICKET] remove opcache.enable_file_override

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -19,7 +19,6 @@ let
       zend.detect_unicode = 0
       opcache.memory_consumption = 256M
       opcache.interned_strings_buffer = 20
-      opcache.enable_file_override = 1
       opcache.enable_cli = 1
       opcache.enabled = 1
       zend.assertions = 0


### PR DESCRIPTION
### 1. Why is this change necessary?
We don't need that cache in development environments, while it throws `Warning: fileperms(): stat failed for /var/www/html/var/cache/*/Shopware_Core_KernelProdDebugContainer.php` after clearing cache-

### 2. What does this change do, exactly?

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
