### PR TITLE
fix: Add missing directory separator in cc script

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -452,7 +452,7 @@ in {
 
     # Symfony related scripts
     scripts.cc.exec = ''
-      CONSOLE=${config.env.DEVENV_ROOT}${cfg.projectRoot}/bin/console
+      CONSOLE=${config.env.DEVENV_ROOT}/${cfg.projectRoot}/bin/console
 
       if test -f "$CONSOLE"; then
         exec $CONSOLE cache:clear


### PR DESCRIPTION
<!--
Thank you for contributing to our devenv project!

It would be helpful if you could provide us with as much information as possible so we can better process your pull request.
Therefore you are given this description template.
-->

### 1. Why is this change necessary?
The `cc` command is not working. It instantly terminates.

### 2. What does this change do, exactly?
A missing directory separator (`/`) is added to the path to `bin/console`.

### 3. Describe each step to reproduce the issue or behavior.
Start a Shopware 6 environment, execute `cc` and you will see no output.

### 4. Please link to the relevant issues (if any).
No issue.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written or adjusted the documentation according to my changes
