### PR TITLE
MySQL Binary Log: Add option to enable/disable

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -260,7 +260,7 @@ in {
 
     enableMysqlBinLog = lib.mkOption {
       type = lib.types.bool;
-      default = true;
+      default = false;
       description = ''Enables MySQL binary logs'';
     };
   };

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -132,3 +132,11 @@ Define packages that should be installed additionally.
 ```
 kellerkinder.additionalPackages = [ pkgs.jpegoptim pkgs.optipng pkgs.gifsicle ];
 ```
+
+# kellerkinder.enableMysqlBinLog
+Enables the MySQL Binary Log and adds configuration for it. Setting this setting to `false` will disable the MySQL Binary Log.
+
+*_Example_*
+```
+kellerkinder.enableMysqlBinLog = false;
+```

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -134,7 +134,7 @@ kellerkinder.additionalPackages = [ pkgs.jpegoptim pkgs.optipng pkgs.gifsicle ];
 ```
 
 # kellerkinder.enableMysqlBinLog
-Enables the MySQL Binary Log and adds configuration for it. Setting this setting to `false` will disable the MySQL Binary Log.
+Enables the MySQL Binary Log and adds configuration for it.
 
 *_Example_*
 ```


### PR DESCRIPTION
### 1. Why is this change necessary?

Before, it was not possible to configure the MySQL bin logs for this setup without using devenv-native configuration.

### 2. What does this change do, exactly?

Adds an option to enable/disable the MySQL bin logs.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
