### PR TITLE
OpenSearch: Add configuration

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -210,6 +210,12 @@ in {
       description = "Enables Elasticsearch";
     };
 
+    enableOpenSearch = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enables OpenSearch";
+    };
+
     enableRabbitMq = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -418,6 +424,7 @@ in {
     services.mailhog.enable = true;
 
     services.elasticsearch.enable = cfg.enableElasticsearch;
+    services.opensearch.enable = cfg.enableOpenSearch;
 
     services.rabbitmq.enable = cfg.enableRabbitMq;
     services.rabbitmq.managementPlugin.enable = cfg.enableRabbitMq;
@@ -441,7 +448,7 @@ in {
 
         NODE_OPTIONS = "--openssl-legacy-provider --max-old-space-size=2000";
       })
-      (lib.mkIf config.services.elasticsearch.enable {
+      (lib.mkIf (config.services.elasticsearch.enable || config.services.opensearch.enable) {
         SHOPWARE_ES_ENABLED = "1";
         SHOPWARE_ES_INDEXING_ENABLED = "1";
         SHOPWARE_ES_HOSTS = "127.0.0.1";

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -65,12 +65,21 @@ kellerkinder.enableRabbitMq = true;
 ```
 
 # kellerkinder.enableElasticsearch
-Enables the Elasticsearch service and configures Shopware to use Elasticsearch in addition to the default
-MySQL search.
+Enables the Elasticsearch service and configures Shopware to use Elasticsearch in addition to the default MySQL search.
+Only one of kellerkinder.enableElasticsearch or kellerkinder.enableOpenSearch should be enabled.
 
 *_Example_*
 ```
 kellerkinder.enableElasticsearch = true;
+```
+
+# kellerkinder.enableOpenSearch
+Enables the OpenSearch service and configures Shopware to use OpenSearch in addition to the default MySQL search.
+Only one of kellerkinder.enableElasticsearch or kellerkinder.enableOpenSearch should be enabled.
+
+*_Example_*
+```
+kellerkinder.enableOpenSearch = true;
 ```
 
 # kellerkinder.importDatabaseDumps


### PR DESCRIPTION
### 1. Why is this change necessary?

It adds an alternative to Elasticsearch to the setup: OpenSearch

### 2. What does this change do, exactly?

It adds a OpenSearch-enabling config setting and the following configuration of the devenv setup. It reuses the Elasticsearch config settings.

### 3. Describe each step to reproduce the issue or behaviour.

-

### 4. Please link to the relevant issues (if any).

-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
