### PR TITLE
Increase node version from 16 to 18

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -274,7 +274,7 @@ in {
 
     languages.javascript = {
       enable = lib.mkDefault true;
-      package = lib.mkDefault pkgs.nodejs-16_x;
+      package = lib.mkDefault pkgs.nodejs-18_x;
     };
 
     languages.php = {


### PR DESCRIPTION
### 1. Why is this change necessary?
```
       error: Package ‘nodejs-16.20.2’ in «github:NixOS/nixpkgs/b85ed9dcbf187b909ef7964774f8847d554fab3b»/pkgs/development/web/nodejs/v16.nix:16 is marked as insecure, refusing to evaluate.
```

### 2. What does this change do, exactly?
Increase default version of nodejs from 16 to 18

### 3. Describe each step to reproduce the issue or behaviour.
Try to start devenv with a fresh installation of this repository.

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
