### PR TITLE
Add ENV variable ES_MULTILINGUAL_INDEX to default ENV variables

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -207,6 +207,7 @@ in {
         NODE_OPTIONS = "--openssl-legacy-provider --max-old-space-size=2000";
       })
       (lib.mkIf (config.services.elasticsearch.enable || config.services.opensearch.enable) {
+        ES_MULTILINGUAL_INDEX = "1";
         SHOPWARE_ES_ENABLED = "1";
         SHOPWARE_ES_INDEXING_ENABLED = "1";
         SHOPWARE_ES_HOSTS = "127.0.0.1";


### PR DESCRIPTION
### 1. Why is this change necessary?

This ENV variable is required to use Advanced Search 2.0, see installation requirements at https://developer.shopware.com/docs/products/extensions/advanced-search/installation.html

### 2. What does this change do, exactly?

It adds ENV variable ES_MULTILINGUAL_INDEX to default ENV variables

### 3. Describe each step to reproduce the issue or behaviour.

Run fully licensed Shopware 6.5.6.1 with Shopware Commercial installed but no ES_MULTILINGUAL_INDEX set.
The config settings for Advanced Search do not appear in the Administration settings.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written or adjusted the documentation according to my changes
