### PR TITLE
Add NPM_CONFIG_ENGINE_STRICT for new npm10

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix
-        run: echo "matrix=$(ls examples/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(ls ${GITHUB_WORKSPACE}/examples/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
   test_examples:
     needs: list-examples
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
       - name: Test ${{ matrix.manifest }} example
         run: |
           cd ${GITHUB_WORKSPACE}/examples/${{ matrix.manifest }}
-          sed -i "s,kellerkinderDE/devenv-shopware?ref=v1.0.2,${GITHUB_REPOSITORY}?ref=${GITHUB_REF_NAME}," devenv.yaml
+          sed -i "s,url: github:kellerkinderDE/devenv-shopware?ref=v1.0.3,url: path:${GITHUB_WORKSPACE}," devenv.yaml
           echo running on ${GITHUB_REPOSITORY} with ref ${GITHUB_REF_NAME}
           direnv allow && direnv reload
           devenv ci -vvv

--- a/devenv.nix
+++ b/devenv.nix
@@ -2,7 +2,7 @@
 let
   cfg = config.kellerkinder;
 
-  currentVersion = "v1.0.2";
+  currentVersion = "v1.0.3";
 
   listEntries = path:
     map (name: path + "/${name}") (builtins.attrNames (builtins.readDir path));
@@ -205,6 +205,7 @@ in {
         SHOPWARE_CACHE_ID = "dev";
 
         NODE_OPTIONS = "--openssl-legacy-provider --max-old-space-size=2000";
+        NPM_CONFIG_ENGINE_STRICT = "false"; # hotfix for npm10
       })
       (lib.mkIf (config.services.elasticsearch.enable || config.services.opensearch.enable) {
         SHOPWARE_ES_ENABLED = "1";

--- a/examples/sw5/devenv.yaml
+++ b/examples/sw5/devenv.yaml
@@ -5,7 +5,7 @@ inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixos-unstable
   kellerkinder:
-    url: github:kellerkinderDE/devenv-shopware?ref=v1.0.2
+    url: github:kellerkinderDE/devenv-shopware?ref=v1.0.3
     flake: false
   phps:
     url: github:fossar/nix-phps

--- a/examples/sw6/devenv.yaml
+++ b/examples/sw6/devenv.yaml
@@ -5,7 +5,7 @@ inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixos-unstable
   kellerkinder:
-    url: github:kellerkinderDE/devenv-shopware?ref=v1.0.2
+    url: github:kellerkinderDE/devenv-shopware?ref=v1.0.3
     flake: false
   phps:
     url: github:fossar/nix-phps


### PR DESCRIPTION
### 1. Why is this change necessary?
Devenv sometimes installs NPM in version 10.X. This version is not supported by sw, due which some commands will fail

### 2. What does this change do, exactly?
Adds a hotfix via env variable to the boot

### 3. Describe each step to reproduce the issue or behaviour.
///
### 4. Please link to the relevant issues (if any).
///
### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
