### PR TITLE
Add custom ports handling

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix
-        run: echo "matrix=$(ls examples/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(ls ${GITHUB_WORKSPACE}/examples/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
   test_examples:
     needs: list-examples
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
       - name: Test ${{ matrix.manifest }} example
         run: |
           cd ${GITHUB_WORKSPACE}/examples/${{ matrix.manifest }}
-          sed -i "s,kellerkinderDE/devenv-shopware?ref=v1.0.2,${GITHUB_REPOSITORY}?ref=${GITHUB_REF_NAME}," devenv.yaml
+          sed -i "s,url: github:kellerkinderDE/devenv-shopware?ref=v2.0.0,url: path:${GITHUB_WORKSPACE}," devenv.yaml
           echo running on ${GITHUB_REPOSITORY} with ref ${GITHUB_REF_NAME}
           direnv allow && direnv reload
           devenv ci -vvv

--- a/devenv.nix
+++ b/devenv.nix
@@ -2,7 +2,7 @@
 let
   cfg = config.kellerkinder;
 
-  currentVersion = "v1.0.2";
+  currentVersion = "v2.0.0";
 
   listEntries = path:
     map (name: path + "/${name}") (builtins.attrNames (builtins.readDir path));

--- a/devenv.nix
+++ b/devenv.nix
@@ -136,8 +136,27 @@ in {
 
     enableMysqlBinLog = lib.mkOption {
       type = lib.types.bool;
-      default = false;
       description = ''Enables MySQL binary logs'';
+      default = false;
+    };
+
+    httpPort = lib.mkOption {
+      type = lib.types.str;
+      description = ''Sets the HTTP port'';
+      default = "80";
+    };
+
+    httpsPort = lib.mkOption {
+      type = lib.types.str;
+      description = ''Sets the HTTPS port'';
+      default = "443";
+    };
+
+    customDomains = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = ''Sets a list of domains (needs additional entries in the hosts)'';
+      default = [];
+      example = [ "mylocal.domain" "kellerkinder.local" ];
     };
   };
 
@@ -194,8 +213,8 @@ in {
         MAILER_URL = lib.mkDefault "smtp://127.0.0.1:1025?encryption=&auth_mode=";
         MAILER_DSN = lib.mkDefault "smtp://127.0.0.1:1025?encryption=&auth_mode=";
 
-        APP_URL = lib.mkDefault "http://127.0.0.1:8000";
-        CYPRESS_baseUrl = lib.mkDefault "http://127.0.0.1:8000";
+        APP_URL = lib.mkDefault "http://127.0.0.1";
+        CYPRESS_baseUrl = lib.mkDefault "http://127.0.0.1";
 
         APP_SECRET = lib.mkDefault "devsecret";
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -165,3 +165,23 @@ Enables the MySQL Binary Log and adds configuration for it.
 ```
 kellerkinder.enableMysqlBinLog = false;
 ```
+
+# kellerkinder.httpPort
+Sets the http port for caddy.
+
+_This has to be a string_
+
+*_Example_*
+```
+kellerkinder.httpPort = "8080";
+```
+
+# kellerkinder.httpsPort
+Sets the https port for caddy.
+
+_This has to be a string_
+
+*_Example_*
+```
+kellerkinder.httpsPort = "8443";
+```

--- a/docs/Update.md
+++ b/docs/Update.md
@@ -1,5 +1,16 @@
 # Updates
 
+
+## v2.0.0
+* If you still want to use custom ports, take a look at the [options](Options.md#kellerkinder-httpPort).
+* You have to adjust your `devenv.yaml` to
+  ```yml
+    ...
+    kellerkinder:
+      url: github:kellerkinderDE/devenv-shopware?ref=v2.0.0
+      flake: false
+    ...
+  ```
 ## v1.0.0
 * You have to update to devenv version `0.6.3` or higher
 * You have to remove `http`, `https` and the ports (e.g. `8000`) from `kellerkinder.additionalServerAlias`

--- a/examples/sw5/devenv.yaml
+++ b/examples/sw5/devenv.yaml
@@ -5,7 +5,7 @@ inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixos-unstable
   kellerkinder:
-    url: github:kellerkinderDE/devenv-shopware?ref=v1.0.2
+    url: github:kellerkinderDE/devenv-shopware?ref=v2.0.0
     flake: false
   phps:
     url: github:fossar/nix-phps

--- a/examples/sw6/devenv.yaml
+++ b/examples/sw6/devenv.yaml
@@ -5,7 +5,7 @@ inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixos-unstable
   kellerkinder:
-    url: github:kellerkinderDE/devenv-shopware?ref=v1.0.2
+    url: github:kellerkinderDE/devenv-shopware?ref=v2.0.0
     flake: false
   phps:
     url: github:fossar/nix-phps

--- a/modules/caddy.nix
+++ b/modules/caddy.nix
@@ -68,13 +68,10 @@ let
 
   caddyHostConfig = (lib.mkMerge
     (lib.forEach vhostDomains (domain: {
-      "http://${toString domain}" = {
+      "http://${toString domain}:${toString cfg.httpPort}" = lib.mkDefault {
         extraConfig = vhostConfig;
       };
-      "https://${toString domain}" = {
-        extraConfig = vhostConfigTls;
-      };
-      "https://${toString domain}:8000" = {
+      "https://${toString domain}:${toString cfg.httpsPort}" = lib.mkDefault {
         extraConfig = vhostConfigTls;
       };
     }))


### PR DESCRIPTION
### 1. Why is this change necessary?
To allow http/https to run on default ports
(and still make them configurable)

### 2. What does this change do, exactly?
Changes the ports for http to 80 and https to 443

### 3. Describe each step to reproduce the issue or behaviour.
///

### 4. Please link to the relevant issues (if any).
#73 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
