### PR TITLE
fix: correct phpConfig for enabled opcache

### DIFF
--- a/modules/php.nix
+++ b/modules/php.nix
@@ -20,7 +20,7 @@ let
       opcache.memory_consumption = 256M
       opcache.interned_strings_buffer = 20
       opcache.enable_cli = 1
-      opcache.enabled = 1
+      opcache.enable = 1
       zend.assertions = 0
       short_open_tag = 0
       xdebug.mode = "debug"


### PR DESCRIPTION
### 1. Why is this change necessary?
The config is `opcache.enable`: https://www.php.net/manual/de/opcache.configuration.php#ini.opcache.enable

### 2. What does this change do, exactly?

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written or adjusted the documentation according to my changes
