### PR TITLE
feat: use new dedicated repo for shopware-cli

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -67,6 +67,26 @@
         "type": "github"
       }
     },
+    "froshpkgs": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1705307227,
+        "narHash": "sha256-Pl3hb7Ez+37jEF0jpU8XcBy7fdkrRLux1x34MCajn1k=",
+        "owner": "FriendsOfShopware",
+        "repo": "nur-packages",
+        "rev": "aec312a79438652bda0894e32b424773bbbcd11b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "FriendsOfShopware",
+        "repo": "nur-packages",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -169,6 +189,7 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "froshpkgs": "froshpkgs",
         "nixpkgs": "nixpkgs",
         "phps": "phps",
         "pre-commit-hooks": "pre-commit-hooks"

--- a/devenv.nix
+++ b/devenv.nix
@@ -157,7 +157,7 @@ in {
     packages = [
       pkgs.jq
       pkgs.gnupatch
-      pkgs.shopware-cli
+      inputs.froshpkgs.packages.${pkgs.system}.shopware-cli
     ] ++ cfg.additionalPackages;
 
     languages.javascript = {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -3,6 +3,11 @@ allowUnfree: true
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixos-unstable
+  froshpkgs:
+    url: github:FriendsOfShopware/nur-packages
+    inputs:
+      nixpkgs:
+        follows: "nixpkgs"
   phps:
     url: github:fossar/nix-phps
     inputs:

--- a/examples/sw5/devenv.yaml
+++ b/examples/sw5/devenv.yaml
@@ -7,6 +7,11 @@ inputs:
   kellerkinder:
     url: github:kellerkinderDE/devenv-shopware?ref=v2.0.0
     flake: false
+  froshpkgs:
+    url: github:FriendsOfShopware/nur-packages
+    inputs:
+      nixpkgs:
+        follows: "nixpkgs"
   phps:
     url: github:fossar/nix-phps
     inputs:

--- a/examples/sw6/devenv.yaml
+++ b/examples/sw6/devenv.yaml
@@ -7,6 +7,11 @@ inputs:
   kellerkinder:
     url: github:kellerkinderDE/devenv-shopware?ref=v2.0.0
     flake: false
+  froshpkgs:
+    url: github:FriendsOfShopware/nur-packages
+    inputs:
+      nixpkgs:
+        follows: "nixpkgs"
   phps:
     url: github:fossar/nix-phps
     inputs:


### PR DESCRIPTION
### 1. Why is this change necessary?
There is a new dedicated repo with more recent release https://github.com/FriendsOfShopware/shopware-cli/commit/5a479bcdc7f8457d4640ae3cc1e02c9d968eb5de

### 2. What does this change do, exactly?
dart-sass-1.69.0.drv' failed to build
shopware-cli-0.4.5.drv' failed to build

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
