### PR TITLE
feat: [noticket] set default mysql config values as recommended by shopware

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -209,6 +209,8 @@ in {
         APP_URL = lib.mkDefault "http://127.0.0.1:${toString cfg.httpPort}";
         CYPRESS_baseUrl = lib.mkDefault "http://127.0.0.1:${toString cfg.httpPort}";
 
+        SQL_SET_DEFAULT_SESSION_VARIABLES = lib.mkDefault "0";
+
         APP_SECRET = lib.mkDefault "devsecret";
 
         PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = true;

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -33,3 +33,23 @@ As mentioned in the features section, devenv is shipped with Xdebug. You need to
 This also works great when having to debug API requests, e.g. in Insomnia.
 
 For the CLI, you can use the integrated debug helper `debug` by simply adding it before your CLI commands, e.g. `debug bin/console`.
+
+
+# MySQL Configuration
+
+The configuration is based on recommendations from Shopware. You can find the documentation [here](https://developer.shopware.com/docs/guides/hosting/performance/performance-tweaks.html#mysql-configuration).
+By default, we change the following configurations:
+
+| setting              | value                                                                                              | description                                                                                                                 |
+|----------------------|----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| group_concat_max_len | 32000                                                                                              | Shopware highly uses GROUP_CONCAT functions within the Database. This setting ensures, that all queries will run correctly. |
+| key_buffer_size      | 16777216                                                                                           | Defines, how many index buffers can be held in memory                                                                       |
+| max_allowed_packet   | 134217728                                                                                          | Defines, how much data can be send within one request before the server blocks it.                                          |
+| table_open_cache     | 1024                                                                                               | Shopware uses many tables, This settings allows the server to keep more tables open                                         |
+| sql_mode             | STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION | the default from MySQL, but without ONLY_FULL_GROUP_BY                                                                      |
+
+
+# Environment variables
+
+We're setting some environment variables as default.
+As example, we're setting SQL_SET_DEFAULT_SESSION_VARIABLES default to `O`, since we're having the shopware recommended configuration for the database.

--- a/modules/mysql.nix
+++ b/modules/mysql.nix
@@ -16,10 +16,11 @@ in {
       settings = {
         mysqld = lib.mkMerge [
           (lib.mkIf cfg.enable {
-            group_concat_max_len = 2048;
+            group_concat_max_len = 32000;
             key_buffer_size = 16777216;
             max_allowed_packet = 134217728;
             table_open_cache = 1024;
+            sql_mode = "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION";
           })
           (lib.mkIf (cfg.enableMysqlBinLog) {
             sync_binlog = 0;


### PR DESCRIPTION
### 1. Why is this change necessary?
Shopware recommends mysql settings here https://developer.shopware.com/docs/guides/hosting/performance/performance-tweaks.html#mysql-configuration 
![image](https://github.com/kellerkinderDE/devenv-shopware/assets/7710527/55a9121c-c5c6-4992-bc26-6b088c95a558)

So we want to have recommendations as default.

### 2. What does this change do, exactly?

Changes the default values from `group_concat_max_len` to `32000` and `sql_mode` to mysql standard, but without `ONLY_FULL_GROUP_BY`.
Also i've added the env variable `SQL_SET_DEFAULT_SESSION_VARIABLES` with the value `0` as default for the setup.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written or adjusted the documentation according to my changes
