### PR TITLE
Change wiki publish to tag releases

### DIFF
--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -19,7 +19,7 @@ jobs:
           regex: true
           include: "docs/*.md"
       - name: Upload Docs to Wiki
-        if: github.ref_name == 'main'
+        if: github.ref_type == 'tag'
         uses: docker://decathlon/wiki-page-creator-action:latest
         env:
           GH_PAT: ${{ secrets.WIKI_ACTION_TOKEN_ServiceUser }}


### PR DESCRIPTION
### 1. Why is this change necessary?
We want the wiki to be compatible with the latest release

### 2. What does this change do, exactly?
Removes the publishing of wikis for every push to main

### 3. Describe each step to reproduce the issue or behaviour.
///

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
