### PR TITLE
Add OPENSEARCH_URL

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -96,6 +96,7 @@ in {
         SHOPWARE_ES_ENABLED = "1";
         SHOPWARE_ES_INDEXING_ENABLED = "1";
         SHOPWARE_ES_HOSTS = "127.0.0.1:${toString cfg.elasticsearchPort}";
+        OPENSEARCH_URL = "127.0.0.1:${toString cfg.elasticsearchPort}";
         SHOPWARE_ES_THROW_EXCEPTION = "1";
       })
       (lib.mkIf config.services.rabbitmq.enable {


### PR DESCRIPTION
### 1. Why is this change necessary?

Since Shopware 6.5 the environment variable to configure the Opensearch URL is no longer called `SHOPWARE_ES_HOSTS` but is now `OPENSEARCH_URL`.

### 2. What does this change do, exactly?

It also sets the env variable `OPENSEARCH_URL` according to the option `cfg.elasticsearchPort` so switching the default port would also work with Shopware 6.5

### 4. Please link to the relevant issues (if any).

https://developer.shopware.com/docs/guides/hosting/infrastructure/elasticsearch/elasticsearch-setup.html#variables-in-your-env

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
