### PR TITLE
Devenv 1.x

### DIFF
--- a/modules/caddy.nix
+++ b/modules/caddy.nix
@@ -83,6 +83,7 @@ in {
       config = ''
         {
           auto_https disable_redirects
+          skip_install_trust
         }
       '';
       virtualHosts = caddyHostConfig;

--- a/modules/php.nix
+++ b/modules/php.nix
@@ -36,7 +36,7 @@ let
   ];
 
   phpVersion = if builtins.hasAttr "PHP_VERSION" config.env then config.env.PHP_VERSION else cfg.phpVersion;
-  package = inputs.phps.packages.${builtins.currentSystem}.${phpVersion};
+  package = inputs.phps.packages.${pkgs.stdenv.system}.${phpVersion};
 
   phpPackage = package.buildEnv {
     extensions = { all, enabled }: with all; enabled

--- a/modules/scripts.nix
+++ b/modules/scripts.nix
@@ -23,7 +23,7 @@ let
       ${pkgs.wait4x}/bin/wait4x http http://localhost:9200/_cluster/health --expect-status-code 200 --timeout 100s
     fi
 
-    TABLE=$(mysql shopware -s -N -e 'SHOW TABLES LIKE "system_config";')
+    TABLE=$($DEVENV_PROFILE/bin/mysql shopware -s -N -e 'SHOW TABLES LIKE "system_config";')
 
     if [[ $TABLE == "" ]]; then
       echo "Table system_config is missing. Run >updateSystemConfig< manually to ensure the dev status of your setup!"


### PR DESCRIPTION
### 1. Why is this change necessary?

These changes ensure compatibility with devenv 1.x

### 2. What does this change do, exactly?

I disabled automatic ca installation for caddy as this prevented the server from starting up when using tls. Furthermore I removed the usage of `currentSystem` because it was removed in devenv version 1.0

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

Fixes #94 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written or adjusted the documentation according to my changes
