### PR TITLE
Add default values for MySQL to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ A description about the setup and usage can be found in the [Wiki](https://githu
 ### Update
 To update your devenv config to the latest version, simply follow the update instructions for the new version in the [Wiki](https://github.com/kellerkinderDE/devenv-shopware/wiki/Update)
 
+### Default values
+#### MySQL
+The default values for MySQL are:
+
+| Type          | Value      |
+|---------------|------------|
+| User          | `shopware` |
+| Password      | `shopware` |
+| Database name | `shopware` |
+
 ## More Information:
 - https://devenv.sh/
 - https://developer.shopware.com/docs/guides/installation/devenv


### PR DESCRIPTION
### 1. Why is this change necessary?
The only place where the default values are currently visible is in the `devenv.nix` file

### 2. What does this change do, exactly?
Adjusts the README.md
### 3. Describe each step to reproduce the issue or behaviour.
Look for the default values
### 4. Please link to the relevant issues (if any).
/
### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written or adjusted the documentation according to my changes
